### PR TITLE
Fix Scope Separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/Provider.php
+++ b/Provider.php
@@ -13,6 +13,8 @@ class Provider extends AbstractProvider
 
     protected $scopes = ['openid goauthentik.io/api profile email'];
 
+    protected $scopeSeparator = ' ';
+
     public static function additionalConfigKeys(): array
     {
         return ['base_url'];


### PR DESCRIPTION
Authentik (as most OAuth2 providers) uses spaces to separate scopes, not commas. This PR fixes it. 